### PR TITLE
Fix bug when dataframe index is not unique

### DIFF
--- a/polyid/polyid.py
+++ b/polyid/polyid.py
@@ -327,8 +327,9 @@ class SingleModel:
             data=predictions, columns=[f"{col}_pred" for col in self.prediction_columns]
         )
 
+        # append the columns with predictions to the original dataframe
         df_prediction_results.index = df_prediction.index
-        df_prediction_results = df_prediction.join(df_prediction_results, how="outer")
+        df_prediction_results = pd.concat([df_prediction, df_prediction_results], axis=1)
 
         return df_prediction_results
 


### PR DESCRIPTION
If the index is not unique, then using `join` to combine the two dataframes creates all possible combinations of matching indexes. `pd.concat` does the expected here, which is a 1:1 mapping.

Since the index is based on the monomers hash, it's not unique across monomers with different distributions. In Mark's case,  what was supposed to be 170 rows turns into 2270 rows.